### PR TITLE
Switch token separate to URL safe character . (dot)

### DIFF
--- a/mailauth/backends.py
+++ b/mailauth/backends.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class MailAuthBackend(ModelBackend):
-    signer = signing.UserSigner(sep='/')
+    signer = signing.UserSigner()
 
     def authenticate(self, request, token=None):
         max_age = getattr(settings, 'LOGIN_URL_TIMEOUT', 60 * 15)

--- a/mailauth/signing.py
+++ b/mailauth/signing.py
@@ -14,6 +14,9 @@ class UserDoesNotExist(signing.BadSignature):
 class UserSigner(signing.TimestampSigner):
     """Issue and verify URL safe access tokens for users."""
 
+    def __init__(self, key=None, sep='.', salt=None):
+        super().__init__(key=key, sep=sep, salt=salt)
+
     @staticmethod
     def to_timestamp(value):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,10 +36,10 @@ def admin_user(db):
 @pytest.fixture()
 def signature():
     """Return a signature matching the user fixture."""
-    return 'LZ/173QUS/1Hjptg/fTLJcaon_7zMDyFTIFtlDqbdSt4'
+    return 'LZ.173QUS.1Hjptg.lf2hFgOXQtjQsFypS2ItRG2hkpA'
 
 
 @pytest.fixture()
 def signer():
     """Return a forzen version of the UserSigner."""
-    return FrozenUserSigner(sep='/')
+    return FrozenUserSigner()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -62,5 +62,5 @@ class TestMailAuthBackend:
         backend = MailAuthBackend()
         MailAuthBackend.signer = signer
         assert backend.get_login_url(signature) == (
-            "/accounts/login/LZ/173QUS/1Hjptg/fTLJcaon_7zMDyFTIFtlDqbdSt4"
+            "/accounts/login/LZ.173QUS.1Hjptg.lf2hFgOXQtjQsFypS2ItRG2hkpA"
         )


### PR DESCRIPTION
Some email clients replace double slashes with a single slash.
The double slash occured for users with no last_login date (newly
created users).

To bypass this issue, the separator is changed to . (dot) as it is
a non-reserved URL safe caracter (RFC3986 2.3) and not port of the
base64url alphabet.

See also:
https://www.ietf.org/rfc/rfc3986.txt
https://tools.ietf.org/html/rfc4648