### PR TITLE
Drop custom separator in favor of default colon (`:`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip setuptools wheel
       - uses: actions/checkout@v2.4.0
-      - run: python -m pip install psycopg2-binary Django~=${{ matrix.django-version }}
+      - run: python -m pip install "psycopg2-binary<2.9" Django~=${{ matrix.django-version }}
       - run: python setup.py test
         env:
           DB_PORT: ${{ job.services.postgres.ports[5432] }}

--- a/mailauth/signing.py
+++ b/mailauth/signing.py
@@ -25,9 +25,6 @@ class UserDoesNotExist(signing.BadSignature):
 class UserSigner(signing.TimestampSigner):
     """Issue and verify URL safe access tokens for users."""
 
-    def __init__(self, key=None, sep=".", salt=None):
-        super().__init__(key=key, sep=sep, salt=salt)
-
     @staticmethod
     def to_timestamp(value):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def signature():
     """Return a signature matching the user fixture."""
     if django.VERSION < (3, 1):
         return "LZ:173QUS:1Hjptg:lf2hFgOXQtjQsFypS2ItRG2hkpA"
-    return "LZ:173QUS:1Hjptg:UtFdkTPoyrSA0IB6AUEhtz_hMyFZY0kcREE1HnWdFq4"
+    return "LZ:173QUS:1Hjptg:6oq5DS1NJ7SxJ1o-CpfgaqrImVaRpkcHrzV9yltwcHM"
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def admin_user(db):
 def signature():
     """Return a signature matching the user fixture."""
     if django.VERSION < (3, 1):
-        return "LZ:173QUS:1Hjptg:lf2hFgOXQtjQsFypS2ItRG2hkpA"
+        return "LZ:173QUS:1Hjptg:umUR9iKN1rxDezT-dZGwqcqsM5Y"
     return "LZ:173QUS:1Hjptg:6oq5DS1NJ7SxJ1o-CpfgaqrImVaRpkcHrzV9yltwcHM"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,8 +38,8 @@ def admin_user(db):
 def signature():
     """Return a signature matching the user fixture."""
     if django.VERSION < (3, 1):
-        return "LZ.173QUS.1Hjptg.lf2hFgOXQtjQsFypS2ItRG2hkpA"
-    return "LZ.173QUS.1Hjptg.UtFdkTPoyrSA0IB6AUEhtz_hMyFZY0kcREE1HnWdFq4"
+        return "LZ:173QUS:1Hjptg:lf2hFgOXQtjQsFypS2ItRG2hkpA"
+    return "LZ:173QUS:1Hjptg:UtFdkTPoyrSA0IB6AUEhtz_hMyFZY0kcREE1HnWdFq4"
 
 
 @pytest.fixture()


### PR DESCRIPTION
Dot is unreserved character, however the representation in browsers (`%2E` or `.`), mail clients and even SMTP-servers is not unified and can lead to different issues:
- https://wordtothewise.com/2018/11/why-do-my-urls-have-two-dots/
- https://bugs.python.org/issue43922

Also, Django is using dot for some funky JSON compression in `django.core.signing`:
https://github.com/django/django/blob/4f8c7fd9d91b35e2c2922de4bb50c8c8066cbbc6/django/core/signing.py#L29-L30

So, in this PR I am suggesting to drop custom separator and switch to the default colon (`:`).
It is also not reserved of anything in domain path, but only in host and scheme parts.
- https://www.rfc-editor.org/rfc/rfc3986#section-3.3
- https://security.stackexchange.com/questions/159099/colons-in-urls-safe
