### PR TITLE
Rename `BaseLoginForm.get_context` to avoid clash with Django internals

### DIFF
--- a/mailauth/forms.py
+++ b/mailauth/forms.py
@@ -42,7 +42,7 @@ class BaseLoginForm(forms.Form):
         """Return the access token."""
         return MailAuthBackend.get_token(user=user)
 
-    def get_context(self, request, user):
+    def get_mail_context(self, request, user):
         """
         Return the context for a message template render.
 
@@ -118,7 +118,7 @@ class EmailLoginForm(BaseLoginForm):
         """
         email = self.cleaned_data[self.field_name]
         for user in self.get_users(email):
-            context = self.get_context(self.request, user)
+            context = self.get_mail_context(self.request, user)
             self.send_mail(email, context)
 
     def send_mail(self, to_email, context):


### PR DESCRIPTION
In Django 4.0 `forms.Form.get_context` was introduced for passing form context in templates.
https://docs.djangoproject.com/en/4.0/ref/forms/api/#django.forms.Form.get_context

Due to this change, we have a clash, as django-mail-auth uses a function with the same name, but for different purpose:

```python
BaseLoginForm.get_context() missing 2 required positional arguments: 'request' and 'user'
```
