### PR TITLE
Add anonymization feature for private user data

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ All Contents
 
     usage
     templates
+    privacy
     customizing
     settings
     contributing

--- a/docs/privacy.rst
+++ b/docs/privacy.rst
@@ -1,0 +1,40 @@
+Privacy
+========
+
+Anonymization
+-------------
+
+User privacy is important, not only to meet local regulations, but also to
+protect your users and allow them to exercise their rights. However,
+it's not always practical to delete users, especially if they have dependent
+objects, that are relevant for statistical analysis.
+
+Anonymization is a process of removing the user's personal data whilst keeping
+related data intact. This is done by using the ``anomymize`` method.
+
+
+
+.. automethod:: mailauth.contrib.user.models.AbstractEmailUser.anonymize
+    :noindex:
+
+This method may be overwritten to provide anonymization for you custom user model.
+
+Related objects may also listen to the anonymize signal.
+
+.. autoclass:: mailauth.contrib.user.signals.anonymize
+
+All those methods can be conveniently triggered via the ``anonymize`` admin action.
+
+.. autoclass:: mailauth.contrib.user.admin.AnonymizableAdminMixin
+    :members:
+
+Liability Waiver
+----------------
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mailauth/contrib/admin/locale/de/LC_MESSAGES/django.po
+++ b/mailauth/contrib/admin/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-12 18:14+0200\n"
+"POT-Creation-Date: 2022-04-14 16:57+0200\n"
 "PO-Revision-Date: 2019-04-12 18:15+0200\n"
 "Last-Translator: Johannes Hoppe <info@johanneshoppe.com>\n"
 "Language-Team: \n"
@@ -65,6 +65,6 @@ msgstr ""
 msgid "Resend login email"
 msgstr "Login E-Mail erneut senden"
 
-#: views.py:16
+#: views.py:17
 msgid "Log in"
 msgstr "Anmelden"

--- a/mailauth/contrib/user/admin.py
+++ b/mailauth/contrib/user/admin.py
@@ -1,12 +1,50 @@
 from django.contrib import admin
 from django.contrib.auth.models import Group, Permission
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from . import models
 
 
+class AnonymizableAdminMixin:
+    """
+    Mixin for admin classes that provides a `anonymize` action.
+
+    This mixin calls the `anonymize` method of all user model instances.
+    """
+
+    actions = ["anonymize"]
+
+    @admin.action(
+        permissions=["anonymize"],
+        description=_("Anonymize selected %(verbose_name_plural)s"),
+    )
+    def anonymize(self, request, queryset):
+        count = queryset.count()
+        for user in queryset.iterator():
+            user.anonymize()
+
+        self.message_user(
+            request,
+            ngettext(
+                "%(count)s %(obj_name)s has successfully been anonymized.",
+                "%(count)s %(obj_name)s have successfully been anonymized.",
+                count,
+            )
+            % {
+                "count": count,
+                "obj_name": self.model._meta.verbose_name_plural
+                if count > 1
+                else self.model._meta.verbose_name,
+            },
+            fail_silently=True,
+        )
+
+    def has_anonymize_permission(self, request, obj=None):
+        return request.user.has_perm(f"{self.opts.app_label}.anonymize", obj=obj)
+
+
 @admin.register(models.EmailUser)
-class EmailUserAdmin(admin.ModelAdmin):
-    app_label = "asdf"
+class EmailUserAdmin(AnonymizableAdminMixin, admin.ModelAdmin):
     list_display = ("email", "first_name", "last_name", "is_staff")
     list_filter = ("is_staff", "is_superuser", "is_active", "groups")
     search_fields = ("first_name", "last_name", "email")

--- a/mailauth/contrib/user/locale/de/LC_MESSAGES/django.po
+++ b/mailauth/contrib/user/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Johannes Hoppe <info@johanneshoppe.com>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-04-14 16:56+0200\n"
+"PO-Revision-Date: 2022-04-14 15:38+0200\n"
+"Last-Translator: Johannes Maron <johannes@maron.family>\n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: admin.py:19
+#, python-format
+msgid "Anonymize selected %(verbose_name_plural)s"
+msgstr "Ausgewählte %(verbose_name_plural)s anonymisieren"
+
+#: admin.py:29
+#, python-format
+msgid "%(count)s %(obj_name)s has successfully been anonymized."
+msgid_plural "%(count)s %(obj_name)s have successfully been anonymized."
+msgstr[0] "%(count)s %(obj_name)s wurde erfolgreich anonymisiert."
+msgstr[1] "%(count)s %(obj_name)s wurden erfolgreich anonymisiert."
+
+#: models.py:56
+msgid "email address"
+msgstr "E-Mail-Adresse"

--- a/mailauth/contrib/user/migrations/0005_emailuser_email_hash_alter_emailuser_email.py
+++ b/mailauth/contrib/user/migrations/0005_emailuser_email_hash_alter_emailuser_email.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+try:
+    from django.contrib.postgres.fields import CIEmailField
+except ImportError:
+    CIEmailField = models.EmailField
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("mailauth_user", "0004_auto_20200812_0722"),
+    ]
+
+    operations = [
+        # add new permissions
+        migrations.AlterModelOptions(
+            name="emailuser",
+            options={
+                "permissions": [("anonymize", "Can anonymize user")],
+                "verbose_name": "user",
+                "verbose_name_plural": "users",
+            },
+        ),
+        # email is now nullable
+        migrations.AlterField(
+            model_name="emailuser",
+            name="email",
+            field=CIEmailField(
+                blank=True,
+                db_index=True,
+                max_length=254,
+                null=True,
+                unique=True,
+                verbose_name="email address",
+            ),
+        ),
+    ]

--- a/mailauth/contrib/user/signals.py
+++ b/mailauth/contrib/user/signals.py
@@ -1,0 +1,19 @@
+from django.dispatch import Signal
+
+anonymize = Signal()
+"""
+Signal that is emitted when a user and all their data should be anonymized.
+
+Usage::
+
+    from django.dispatch import receiver
+    from mailauth.contrib.user.models import EmailUser
+    from mailauth.contrib.user.signals import anonymize
+
+
+    @receiver(anonymize, sender=EmailUser)
+    def anonymize_user(sender, instance, update_fields, **kwargs):
+        # Do something with related user data
+        instance.related_model.delete()
+
+"""

--- a/tests/contrib/auth/test_admin.py
+++ b/tests/contrib/auth/test_admin.py
@@ -1,0 +1,71 @@
+from unittest.mock import Mock
+
+import pytest
+from django.contrib import admin
+from django.contrib.auth.models import Permission
+
+from mailauth.contrib.user.admin import AnonymizableAdminMixin
+from mailauth.contrib.user.models import EmailUser
+
+
+class TestAnonymizableAdminMixin:
+    def test_anonymize__none(self, rf):
+        class MyUserModel(EmailUser):
+            class Meta:
+                app_label = "test"
+                verbose_name = "singular"
+                verbose_name_plural = "plural"
+
+        class MyModelAdmin(AnonymizableAdminMixin, admin.ModelAdmin):
+            pass
+
+        request = rf.get("/")
+        MyModelAdmin(MyUserModel, admin.site).anonymize(
+            request, MyUserModel.objects.none()
+        )
+
+    @pytest.mark.django_db
+    def test_anonymize__one(self, rf, user, monkeypatch):
+        class MyModelAdmin(AnonymizableAdminMixin, admin.ModelAdmin):
+            pass
+
+        monkeypatch.setattr(EmailUser, "anonymize", Mock())
+
+        request = rf.get("/")
+        MyModelAdmin(type(user), admin.site).anonymize(
+            request, type(user).objects.all()
+        )
+        assert EmailUser.anonymize.was_called_once_with(user)
+
+    @pytest.mark.django_db
+    def test_anonymize__many(self, rf, user, monkeypatch):
+        class MyModelAdmin(AnonymizableAdminMixin, admin.ModelAdmin):
+            pass
+
+        monkeypatch.setattr(EmailUser, "anonymize", Mock())
+
+        request = rf.get("/")
+        MyModelAdmin(type(user), admin.site).anonymize(
+            request, type(user).objects.all()
+        )
+        assert EmailUser.anonymize.was_called_once_with(user)
+
+    def test_has_anonymize_permission(self, rf, user):
+        class MyModelAdmin(AnonymizableAdminMixin, admin.ModelAdmin):
+            pass
+
+        user.is_staff = True
+        user.save()
+        request = rf.get("/")
+        request.user = user
+        assert not MyModelAdmin(type(user), admin.site).has_anonymize_permission(
+            request
+        )
+
+        permission = Permission.objects.get(
+            codename="anonymize",
+        )
+        user.user_permissions.add(permission)
+        del user._perm_cache
+        del user._user_perm_cache
+        assert MyModelAdmin(type(user), admin.site).has_anonymize_permission(request)

--- a/tests/contrib/auth/test_signals.py
+++ b/tests/contrib/auth/test_signals.py
@@ -1,0 +1,20 @@
+from unittest.mock import Mock
+
+import pytest
+from django.dispatch import receiver
+
+from mailauth.contrib.user.signals import anonymize
+
+
+@pytest.mark.django_db
+def test_anonymize(user):
+    handler = Mock()
+    receiver(anonymize, sender=user.__class__)(handler)
+    handler.assert_not_called()
+    user.anonymize()
+    handler.assert_called_once_with(
+        signal=anonymize,
+        sender=user.__class__,
+        instance=user,
+        update_fields=("email", "first_name", "last_name"),
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,3 +20,22 @@ class TestEmailUser:
         models.EmailUser.objects.create_user("IronMan@avengers.com")
         with pytest.raises(IntegrityError):
             models.EmailUser.objects.create_user("ironman@avengers.com")
+
+    @pytest.mark.django_db
+    def test_anonymize(self):
+        user = models.EmailUser.objects.create_user(
+            email="ironman@avengers.com", first_name="Tony", last_name="Stark"
+        )
+        assert user.anonymize() == ["email", "first_name", "last_name"]
+        assert not user.first_name
+        assert not user.last_name
+        assert not user.email
+
+    def test_anonymize__no_commit(self):
+        user = models.EmailUser(
+            email="ironman@avengers.com", first_name="Tony", last_name="Stark"
+        )
+        user.anonymize(commit=False)
+        assert not user.first_name
+        assert not user.last_name
+        assert not user.email


### PR DESCRIPTION
User privacy is important, not only to meet local regulations, but also to
protect your users and allow them to exercise their rights. However,
it's not always practical to delete users, especially if they have dependent
objects, that are relevant for statistical analysis.

Anonymization is a process of removing the user's personal data whilst keeping
related data intact. This is done by using the ``anonymize`` method.